### PR TITLE
update: ログイン後にユーザごとのページに遷移するよう変更

### DIFF
--- a/frontend/src/app/(authenticated)/main/page.tsx
+++ b/frontend/src/app/(authenticated)/main/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { useEffect } from "react";
+
+export default function MainPage() {
+  const { user, isLoading } = useUser();
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      window.location.href = `/${user.nickname}`;
+    }
+  }, [isLoading, user]);
+
+  return (
+    <div>
+    </div>
+  );
+}


### PR DESCRIPTION
いろいろ試したが、[こちら](https://community.auth0.com/t/redirect-user-to-a-dynamic-route-which-is-basically-its-userid-or-organizationid-got-from-idtoken/132547/4)によるとログイン認証成功後のリダイレクトは1つのurlしか設定できないということだったので、/mainにリダイレクトさせて/mainからユーザーごとのページにリダイレクトさせるようにした。
